### PR TITLE
Adds libgd as provider to package definition

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,5 +3,9 @@ import PackageDescription
 
 let package = Package(
     name: "Cgd",
-    pkgConfig: "gdlib"
+    pkgConfig: "gdlib",
+    providers: [
+        .brew(["gd"]),
+        .apt(["libgd-dev"])
+    ]
 )


### PR DESCRIPTION
This PR adds `libgd` provider for macOS & Linux.
So if libgd is missing on the machine, it will print something like this:

```sh
$ swift build             
Fetching https://github.com/twostraws/Cgd.git
Cloning https://github.com/twostraws/Cgd.git
Resolving https://github.com/twostraws/Cgd.git at master
warning: you may be able to install gdlib using your system-packager:
warning:     brew install gd
...
```

